### PR TITLE
[FIX] website_security: Compute error while creating new menu item

### DIFF
--- a/website_security/models/website.py
+++ b/website_security/models/website.py
@@ -36,6 +36,8 @@ class website_menu(models.Model):
     @api.one
     @api.depends('url')
     def get_related_view(self):
+        if not self.url:
+            return
         view = False
         page = self.url.split('/')
         page = page and page[-1] or False


### PR DESCRIPTION
Hey,

we use a mix of odoo v8 and v9 and installed the website_security addon. If we create a new menu item we get the following error:

```
Traceback (most recent call last):
  File "/var/www/openerp/http.py", line 533, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/var/www/openerp/http.py", line 570, in dispatch
    result = self._call_function(**self.params)
  File "/var/www/openerp/http.py", line 306, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/var/www/openerp/service/model.py", line 113, in wrapper
    return f(dbname, *args, **kwargs)
  File "/var/www/openerp/http.py", line 303, in checked_call
    return self.endpoint(*a, **kw)
  File "/var/www/openerp/http.py", line 808, in __call__
    return self.method(*args, **kw)
  File "/var/www/openerp/http.py", line 399, in response_wrap
    response = f(*args, **kw)
  File "/var/www/addons/web/controllers/main.py", line 969, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/var/www/addons/web/controllers/main.py", line 961, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/var/www/openerp/api.py", line 241, in wrapper
    return old_api(self, *args, **kwargs)
  File "/var/www/openerp/api.py", line 363, in old_api
    result = method(recs, *args, **kwargs)
  File "/var/www/openerp/models.py", line 5804, in onchange
    value = record[name]
  File "/var/www/openerp/models.py", line 5539, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/var/www/openerp/fields.py", line 769, in __get__
    self.determine_draft_value(record)
  File "/var/www/openerp/fields.py", line 877, in determine_draft_value
    self._compute_value(record)
  File "/var/www/openerp/fields.py", line 816, in _compute_value
    self.compute(records)
  File "/var/www/openerp/api.py", line 239, in wrapper
    return new_api(self, *args, **kwargs)
  File "/var/www/openerp/api.py", line 397, in new_api
    result = [method(rec, *args, **kwargs) for rec in self]
  File "/var/www/addons_extern/website_security/models/website.py", line 40, in get_related_view
    page = self.url.split('/')
AttributeError: 'bool' object has no attribute 'split'
```

I added if clause for checking if the url is set or not.
# Steps to Reproduce
1. if not installed yet, install website_security
2. log in as admin
3. go to tab website in backend
4. go to website menu
5. click on Create
